### PR TITLE
refactor(ci): migrate pipeline to uv

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -2,28 +2,27 @@ name: CI - Lint & Tests
 
 on:
   pull_request:
-    branches: [ "main", "develop" ]
+    branches: ["main", "develop"]
 
 jobs:
   ci:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-    - name: Set up Python
-      uses: actions/setup-python@v3
-      with:
-        python-version: "3.10"
+      - name: Install uv
+        run: pip install uv
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
+      - name: Set up Python
+        run: uv python install 3.10
 
-    - name: Lint (flake8)
-      run: flake8 .
+      - name: Install dependencies
+        run: uv sync
 
-    - name: Run tests
-      run: pytest
+      - name: Lint (flake8)
+        run: uv run flake8 .
+
+      - name: Run tests
+        run: uv run pytest


### PR DESCRIPTION
Migrate GitHub Actions workflow from pip to uv for dependency management.

Changes:
- Replace pip install with uv sync
- Use uv run for linting and testing
- Remove setup-python in favor of uv-managed Python

Benefits:
- Faster dependency resolution
- Reproducible environments via uv.lock
- Cleaner and more modern Python workflow