### PR TITLE
feat(security): implement keystore backup/restore and D6 threat model documentation

### DIFF
--- a/docs/Key Store Module.md
+++ b/docs/Key Store Module.md
@@ -60,19 +60,52 @@ Si el usuario se entera que su dispositivo fue robado o su contraseña expuesta,
 - **Acción del Backend:** La base de datos actualiza el estado de la llave pública comprometida a `REVOKED` (Revocada). 
 - **Aislamiento:** Desde ese momento, el backend rechaza cualquier petición que provenga de dicha identidad para descargar archivos `.vault`, mitigando la exfiltración de datos. Además, de advertir a sus contactos del usuario que las firmas asociadas a esa llave ya no son confiables.
 
-# Security assumptions
-El modelo de amenazas de este módulo se basa en las siguientes suposiciones:
+# Security Assumptions (Supuestos de Seguridad)
+El modelo de amenazas de este módulo se basa en los siguientes supuestos:
 
-- **Entropía de la contraseña**: El usuario elige una contraseña lo suficientemente fuerte como para resistir ataques de diccionario (frases o patrones comunes).
-- **Integridad del cliente**: El dispositivo donde el usuario introduce su contraseña y descifra la llave en la memoria RAM está libre de malware, keyloggers o acceso no autorizado.
-- **Resguardo físico**: El usuario almacena su llave (frase) de recuperación o su archivo de backup de forma segura y fuera del alcance de terceros.
+- **Entropía de la contraseña**: El usuario elige una contraseña robusta (alta entropía) que no pueda ser adivinada mediante ataques sencillos de diccionario.
+- **Integridad del cliente**: El dispositivo físico donde el usuario ejecuta el software y descifra su llave privada en la memoria RAM está libre de troyanos, keyloggers, spywares o acceso remoto no autorizado.
+- **Almacenamiento del Backup**: El usuario resguarda sus archivos de respaldo (`.keystore`) y su frase de recuperación de 12 palabras de forma segura y separada del entorno de producción habitual.
 
-# Security Discussion
-## Why encrypt private keys?
-Uno de los eslabones más débiles de un sistema criptográfico es el almacenamiento de las llaves. Si la base de datos es vulnerada o un disco duro es robado, el cifrado garantiza que las llaves privadas (y todos los archivos del Vault) permanezcan confidenciales. Un atacante que obtenga el Keystore solo poseerá "ruido" incomprensible sin el secreto (contraseña) del usuario. 
+# Threat Model Alignment & Security Discussion (Alineación con el Modelo de Amenazas y Discusión de Seguridad)
 
-## What happens if the password is weak?
-Si la contraseña es débil (ej. "123456"), un atacante que robe o tenga acceso al Keystore puede realizar un ataque de fuerza bruta offline. A pesar de que las 600,000 iteraciones de PBKDF2 hacen que cada intento sea computacionalmente costoso, una contraseña con baja entropía (aleatoreidad) terminará siendo vulnerada. El sistema no puede proteger al usuario de sus propias malas prácticas de creación de contraseñas.
+Para cumplir formalmente con las directrices del entregable D6, detallamos a continuación las respuestas a las interrogantes de seguridad críticas:
 
-## System Limitations
-Debido a la arquitectura de "Zero-Knowledge", el servidor es ciego, es decir, el sistema no puede ofrecer una funcionalidad tradicional de "Olvidé mi contraseña" por correo electrónico. Si un usuario olvida su contraseña y también pierde su frase de recuperación, sus documentos quedarán cifrados e inaccesibles para siempre.
+### 1. ¿Qué pasa si un atacante roba el Keystore? (What if an attacker steals the keystore?)
+Si un atacante externo o un administrador malicioso del servidor obtiene acceso al almacenamiento y roba el archivo JSON del Keystore (o la base de datos de respaldo), **no podrá descifrar ni extraer las llaves privadas del usuario** de forma directa. 
+- **Razón técnica:** Las llaves privadas están cifradas con **ChaCha20Poly1305** usando una llave KEK de 256 bits derivada de la contraseña a través de **PBKDF2-HMAC-SHA256** con **600,000 iteraciones**.
+- **Seguridad:** A menos que el atacante posea o logre adivinar la contraseña maestra del usuario, el Keystore robado es indistinguible de ruido aleatorio criptográfico. Además, al usar cifrado autenticado (AEAD), cualquier intento de modificar los bits del Keystore robado para vulnerar el sistema será detectado inmediatamente al verificar la firma de autenticación (Tag), provocando que el descifrado aborte de inmediato.
+
+### 2. ¿Qué pasa si la contraseña es débil? (What if a password is weak?)
+Si la contraseña del usuario es débil (baja entropía, ej. "123456" o "password"), la seguridad del sistema se ve **gravemente comprometida** si el atacante logra exfiltrar el Keystore.
+- **Vulnerabilidad:** Aunque las 600,000 iteraciones de PBKDF2 ralentizan drásticamente los intentos de adivinación (haciendo que los ataques con hardware masivo como GPUs sean extremadamente costosos), una contraseña de diccionario o muy corta terminará siendo revelada mediante un ataque de fuerza bruta offline.
+- **Mitigación:** El sistema ralentiza el ataque, pero no puede sustituir la falta de entropía del secreto elegido por el usuario. Es responsabilidad del usuario elegir contraseñas de alta calidad.
+
+### 3. ¿Qué pasa si el dispositivo del usuario está comprometido? (What if a device is compromised?)
+Si el dispositivo final del usuario está infectado con malware, tiene un keylogger activo, o un atacante tiene control total (root/administrador), **todas las garantías de seguridad criptográfica se pierden por completo**.
+- **Impacto:** El atacante podría interceptar la contraseña maestra cuando el usuario la escribe, extraer la clave privada en texto plano directamente desde la memoria RAM mientras está desbloqueada temporalmente, o manipular la lógica de la aplicación para exfiltrar las llaves de los archivos antes de que sean destruidas. 
+- **Postura del sistema:** El sistema se diseña asumiendo que el dispositivo cliente mantiene su integridad operacional (Supuesto de Cliente Confiable). La criptografía protege los datos "en tránsito" y "en reposo hostil", pero no puede defenderse de un entorno de ejecución local corrupto.
+
+---
+
+## Preguntas de Discusión Requeridas (D6 Rubric)
+
+### ¿Por qué cifrar las llaves privadas? (Why encrypt private keys?)
+La llave privada es la raíz de toda la identidad, firma y capacidad de descifrado del usuario en la bóveda. Si las llaves privadas se almacenaran en texto plano en el disco local o base de datos, cualquier compromiso del sistema operativo, robo físico del dispositivo o exfiltración de archivos revelaría inmediatamente el acceso total a todos los documentos históricos y futuros del usuario. Cifrar la llave privada bajo una contraseña derivada asegura que el material criptográfico más crítico permanezca protegido incluso si el medio de almacenamiento es totalmente hostil.
+
+### ¿Qué protege y qué NO protege nuestro sistema? (Protections vs. Non-Protections)
+
+#### Lo que SÍ protege:
+- **Compromiso del Servidor (Server Compromise):** Un atacante que controle la base de datos central o los servidores en la nube no puede descifrar los archivos ni las llaves privadas de los usuarios.
+- **Ataques en el Canal de Comunicación (Man-in-the-Middle):** El tráfico interceptado solo contiene paquetes cifrados y firmas digitales verificables.
+- **Alteraciones del Contenedor (Tampering):** Gracias al uso de AEAD (ChaCha20Poly1305), cualquier modificación no autorizada de los datos o metadatos del Keystore o los archivos `.vault` es detectada y rechazada.
+- **Ataques offline de fuerza bruta tradicionales:** Mediante el alto número de iteraciones (600k) de PBKDF2, se disuade la fuerza bruta rápida para contraseñas de entropía media/alta.
+
+#### Lo que NO protege (Supuestos excluidos):
+- **Malware y Compromiso de Dispositivo Local:** Keyloggers, extractores de memoria RAM o rootkits que comprometan el cliente.
+- **Entropía Nula en Contraseñas:** Contraseñas extremadamente cortas o comunes (susceptibles a ataques offline de fuerza bruta).
+- **Pérdida de Credenciales de Recuperación:** Si el usuario olvida su contraseña maestra y pierde su frase de recuperación, la información cifrada es permanentemente inaccesible (arquitectura Zero-Knowledge).
+- **Ingeniería Social y Coerción:** Phishing o coerción física/legal al usuario para revelar la clave o contraseña.
+
+### Limitaciones del Sistema (System Limitations)
+La principal limitación radica en el modelo de **Cero Conocimiento (Zero-Knowledge)**. Debido a que el servidor no almacena contraseñas ni llaves en texto plano, no existe un flujo centralizado de "Restablecer Contraseña por Email". Si un usuario pierde tanto su contraseña como su frase semilla, no hay forma matemática ni técnica de recuperar su cuenta, resultando en la pérdida irreversible de sus datos.

--- a/docs/Secure Vault Documentation.md
+++ b/docs/Secure Vault Documentation.md
@@ -34,9 +34,9 @@ Características principales
 * Cifrado híbrido (key wrapping con RSA/ECC) para proteger las claves simétricas de cada archivo mediante las llaves públicas de los destinatarios.
 * Firma digital obligatoria de los documentos para garantizar la autenticidad.
 * Verificación de la firma antes de descifrar el contenido.
-* Gestión de claves con KDF (Argon2 / PBKDF2).
-* Respaldo de las llaves.
-* Mecanismo de recuperación de las llaves.
+* Gestión de claves robusta con PBKDF2 (600,000 iteraciones) y protección mediante KEK.
+* Respaldo y exportación/importación segura de Keystores locales (`.keystore`) mediante operaciones I/O confiables.
+* Mecanismo de recuperación fuera de línea (offline) empleando frases semilla mnemónicas.
 * Capacidad para compartir con múltiples usuarios.
 * Formato: CLI o aplicación local.
 

--- a/src/secure_document_vault/modules/key_store/generator.py
+++ b/src/secure_document_vault/modules/key_store/generator.py
@@ -1,4 +1,5 @@
 import os
+import json
 import base64
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
@@ -81,3 +82,25 @@ class KeyProtector:
         )
 
         return private_key_obj
+
+    @staticmethod
+    def backup_keystore(keystore_dict: dict, filepath: str) -> None:
+        """
+        Escribe el diccionario de Keystore en un archivo local usando json.dump.
+        """
+        dirname = os.path.dirname(filepath)
+        if dirname and not os.path.exists(dirname):
+            os.makedirs(dirname)
+        with open(filepath, "w", encoding="utf-8") as f:
+            json.dump(keystore_dict, f, indent=4)
+
+    @staticmethod
+    def restore_keystore(filepath: str) -> dict:
+        """
+        Lee un archivo .keystore (o JSON) desde el disco usando json.load
+        y retorna el diccionario para el KeyProtector.
+        """
+        if not os.path.exists(filepath):
+            raise FileNotFoundError(f"El archivo de keystore no existe: {filepath}")
+        with open(filepath, "r", encoding="utf-8") as f:
+            return json.load(f)

--- a/src/secure_document_vault/modules/key_store/generator.py
+++ b/src/secure_document_vault/modules/key_store/generator.py
@@ -16,7 +16,7 @@ class KeyProtector:
         private_key_bytes = private_key_obj.private_bytes(
             encoding=serialization.Encoding.PEM,
             format=serialization.PrivateFormat.PKCS8,
-            encryption_algorithm=serialization.NoEncryption()
+            encryption_algorithm=serialization.NoEncryption(),
         )
 
         # Generar un salt pseudo aleatorio criptograficamente seguro
@@ -28,9 +28,9 @@ class KeyProtector:
             algorithm=hashes.SHA256(),
             length=32,  # Llave de 256 bits
             salt=salt,
-            iterations=600_000
+            iterations=600_000,
         )
-        kek = kdf.derive(password.encode('utf-8'))
+        kek = kdf.derive(password.encode("utf-8"))
 
         # Cifrar llave con bytes de llave usando ChaCha20
         nonce = os.urandom(12)
@@ -38,17 +38,14 @@ class KeyProtector:
         encrypted_key = chacha20.encrypt(nonce, private_key_bytes, None)
 
         return {
-            "metadata": {
-                "user_id": user_id,
-                "description": "Encrypted Private Key"
-            },
+            "metadata": {"user_id": user_id, "description": "Encrypted Private Key"},
             "kdf_parameters": {
                 "kdf_algorithm": "PBDKF2-HMAC-SHA256",
                 "iterations": 600_000,
-                "salt": base64.b64encode(salt).decode('utf-8')
+                "salt": base64.b64encode(salt).decode("utf-8"),
             },
-            "nonce": base64.b64encode(nonce).decode('utf-8'),
-            "encrypted_key": base64.b64encode(encrypted_key).decode('utf-8')
+            "nonce": base64.b64encode(nonce).decode("utf-8"),
+            "encrypted_key": base64.b64encode(encrypted_key).decode("utf-8"),
         }
 
     @staticmethod
@@ -63,10 +60,10 @@ class KeyProtector:
             algorithm=hashes.SHA256(),
             length=32,  # Llave dde 256 bits
             salt=salt,
-            iterations=iterations
+            iterations=iterations,
         )
 
-        kek = kdf.derive(password.encode('utf-8'))
+        kek = kdf.derive(password.encode("utf-8"))
 
         chacha = ChaCha20Poly1305(kek)
 
@@ -77,8 +74,7 @@ class KeyProtector:
             raise ValueError("CONTRASEÑA INCORRECTA O KEYSTORE CORRUPTO")
 
         private_key_obj = serialization.load_pem_private_key(
-            recovered_key_bytes,
-            password=None
+            recovered_key_bytes, password=None
         )
 
         return private_key_obj

--- a/src/secure_document_vault/modules/key_store/tests/test_keystore.py
+++ b/src/secure_document_vault/modules/key_store/tests/test_keystore.py
@@ -21,22 +21,26 @@ def create_user(user_id):
 
 def test_correct_password():
     """Verifies that access is granted when password is correct"""
-    bob = create_user('bob-123')
+    bob = create_user("bob-123")
     # Derive KEK
     protected_key_dict = KeyProtector.protect_key(
-        "Secret_password-123", bob["private_key"], bob["id"])
+        "Secret_password-123", bob["private_key"], bob["id"]
+    )
 
     # Get the original key with the password
-    recovered_key = KeyProtector.verify_password("Secret_password-123",
-                                                 protected_key_dict)
+    recovered_key = KeyProtector.verify_password(
+        "Secret_password-123", protected_key_dict
+    )
 
-    original_key_bytes = bob["private_key"].public_key().public_bytes(
-        encoding=serialization.Encoding.Raw,
-        format=serialization.PublicFormat.Raw
+    original_key_bytes = (
+        bob["private_key"]
+        .public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.Raw, format=serialization.PublicFormat.Raw
+        )
     )
     recovered_key_bytes = recovered_key.public_key().public_bytes(
-        encoding=serialization.Encoding.Raw,
-        format=serialization.PublicFormat.Raw
+        encoding=serialization.Encoding.Raw, format=serialization.PublicFormat.Raw
     )
 
     assert original_key_bytes == recovered_key_bytes
@@ -44,22 +48,22 @@ def test_correct_password():
 
 def test_wrong_password():
     """Verifies that access is not granted when password is incorrect"""
-    bob = create_user('bob-123')
+    bob = create_user("bob-123")
     # Derive KEK
     protected_key_dict = KeyProtector.protect_key(
-        "Secret_password-123", bob["private_key"], bob["id"])
+        "Secret_password-123", bob["private_key"], bob["id"]
+    )
 
-    with pytest.raises(ValueError,
-                       match="CONTRASEÑA INCORRECTA O KEYSTORE CORRUPTO"):
-        KeyProtector.verify_password("Incorrect_password-123",
-                                     protected_key_dict)
+    with pytest.raises(ValueError, match="CONTRASEÑA INCORRECTA O KEYSTORE CORRUPTO"):
+        KeyProtector.verify_password("Incorrect_password-123", protected_key_dict)
 
 
 def test_modified_keystore():
     """Verifies if keystore is modified"""
     alice = create_user("alice-567")
     protected_key_dict = KeyProtector.protect_key(
-        "password-12345", alice["private_key"], alice["id"])
+        "password-12345", alice["private_key"], alice["id"]
+    )
 
     protected_key = protected_key_dict["encrypted_key"]
 
@@ -71,12 +75,11 @@ def test_modified_keystore():
     decoded_key[0] ^= 1
 
     # Store again in the dict and try to get the key again
-    encoded_key = base64.b64encode(decoded_key).decode('utf-8')
+    encoded_key = base64.b64encode(decoded_key).decode("utf-8")
     protected_key_dict["encrypted_key"] = encoded_key
 
     # Try to get the key with the correct password
-    with pytest.raises(ValueError,
-                       match="CONTRASEÑA INCORRECTA O KEYSTORE CORRUPTO"):
+    with pytest.raises(ValueError, match="CONTRASEÑA INCORRECTA O KEYSTORE CORRUPTO"):
         KeyProtector.verify_password("password-12345", protected_key_dict)
 
 
@@ -85,8 +88,9 @@ def test_backup():
     password = "MySecureBackupPassword!"
     original_private_key = ed25519.Ed25519PrivateKey.generate()
 
-    keystore_dict = KeyProtector.protect_key(password, original_private_key,
-                                             "user-backup")
+    keystore_dict = KeyProtector.protect_key(
+        password, original_private_key, "user-backup"
+    )
 
     backup_json_string = json.dumps(keystore_dict)
 
@@ -97,25 +101,23 @@ def test_backup():
     recovered_key = KeyProtector.verify_password(password, restored_dict)
 
     original_pub_bytes = original_private_key.public_key().public_bytes(
-        encoding=serialization.Encoding.Raw,
-        format=serialization.PublicFormat.Raw
+        encoding=serialization.Encoding.Raw, format=serialization.PublicFormat.Raw
     )
     recovered_pub_bytes = recovered_key.public_key().public_bytes(
-        encoding=serialization.Encoding.Raw,
-        format=serialization.PublicFormat.Raw
+        encoding=serialization.Encoding.Raw, format=serialization.PublicFormat.Raw
     )
 
     assert original_pub_bytes == recovered_pub_bytes
 
 
 def test_stolen_keystore_alone():
-    """Verifies that when keystore is stolen, cannot decrypt anything
-    """
+    """Verifies that when keystore is stolen, cannot decrypt anything"""
     password = "UserStrongPassword"
     original_private_key = ed25519.Ed25519PrivateKey.generate()
 
-    stolen_keystore = KeyProtector.protect_key(password, original_private_key,
-                                               "user-victim")
+    stolen_keystore = KeyProtector.protect_key(
+        password, original_private_key, "user-victim"
+    )
 
     raw_stolen_bytes = base64.b64decode(stolen_keystore["encrypted_key"])
 
@@ -125,8 +127,9 @@ def test_stolen_keystore_alone():
     attacker_guesses = ["123456", "password", "admin", "user-victim"]
 
     for guess in attacker_guesses:
-        with pytest.raises(ValueError,
-                           match="""CONTRASEÑA INCORRECTA O KEYSTORE CORRUPTO"""):
+        with pytest.raises(
+            ValueError, match="""CONTRASEÑA INCORRECTA O KEYSTORE CORRUPTO"""
+        ):
             KeyProtector.verify_password(guess, stolen_keystore)
 
 
@@ -139,7 +142,9 @@ def test_backup_restore_file(tmp_path):
     original_private_key = ed25519.Ed25519PrivateKey.generate()
 
     # Generar keystore
-    keystore_dict = KeyProtector.protect_key(password, original_private_key, "user-backup-io")
+    keystore_dict = KeyProtector.protect_key(
+        password, original_private_key, "user-backup-io"
+    )
 
     # Definir ruta de archivo temporal
     backup_file = tmp_path / "user.keystore"
@@ -158,12 +163,10 @@ def test_backup_restore_file(tmp_path):
     recovered_key = KeyProtector.verify_password(password, restored_dict)
 
     original_pub_bytes = original_private_key.public_key().public_bytes(
-        encoding=serialization.Encoding.Raw,
-        format=serialization.PublicFormat.Raw
+        encoding=serialization.Encoding.Raw, format=serialization.PublicFormat.Raw
     )
     recovered_pub_bytes = recovered_key.public_key().public_bytes(
-        encoding=serialization.Encoding.Raw,
-        format=serialization.PublicFormat.Raw
+        encoding=serialization.Encoding.Raw, format=serialization.PublicFormat.Raw
     )
 
     assert original_pub_bytes == recovered_pub_bytes

--- a/src/secure_document_vault/modules/key_store/tests/test_keystore.py
+++ b/src/secure_document_vault/modules/key_store/tests/test_keystore.py
@@ -128,3 +128,42 @@ def test_stolen_keystore_alone():
         with pytest.raises(ValueError,
                            match="""CONTRASEÑA INCORRECTA O KEYSTORE CORRUPTO"""):
             KeyProtector.verify_password(guess, stolen_keystore)
+
+
+def test_backup_restore_file(tmp_path):
+    """
+    Verifica que las operaciones I/O de respaldo (backup) y restauración (restore)
+    a nivel de archivo físico funcionan correctamente empleando un archivo temporal.
+    """
+    password = "MySecureBackupPassword!"
+    original_private_key = ed25519.Ed25519PrivateKey.generate()
+
+    # Generar keystore
+    keystore_dict = KeyProtector.protect_key(password, original_private_key, "user-backup-io")
+
+    # Definir ruta de archivo temporal
+    backup_file = tmp_path / "user.keystore"
+
+    # Exportar (Backup)
+    KeyProtector.backup_keystore(keystore_dict, str(backup_file))
+    assert backup_file.exists()
+
+    # Importar (Restore)
+    restored_dict = KeyProtector.restore_keystore(str(backup_file))
+
+    # Verificar que el contenido importado sea idéntico
+    assert restored_dict == keystore_dict
+
+    # Verificar descifrado con la llave restaurada
+    recovered_key = KeyProtector.verify_password(password, restored_dict)
+
+    original_pub_bytes = original_private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw
+    )
+    recovered_pub_bytes = recovered_key.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw
+    )
+
+    assert original_pub_bytes == recovered_pub_bytes


### PR DESCRIPTION
## Summary
This PR completes Issue 3 of the D6 deliverable, implementing physical file persistence for local keystores and the theoretical threat model documentation.

---

## Changes

### Code
* **`backup_keystore`**: Writes the keystore dictionary to a local file using `json.dump`.
* **`restore_keystore`**: Reads and restores the keystore from disk using `json.load`.
* **Tests**: Added `test_backup_restore_file` to verify physical write and read operations.

### Documentation
* **`Key Store Module.md`**: Answered threat model questions (stolen keystore, weak passwords, compromised devices, protections vs assumptions).
* **`Secure Vault Documentation.md`**: Updated technical features to reflect PBKDF2 iterations and backup capabilities.

---

## Testing
Ran the full test suite and all tests passed successfully:
* **78 tests passed (100% success rate).**
